### PR TITLE
Ignore error when sending msg to disconnected client

### DIFF
--- a/src/main/java/io/github/ytung/tractor/TractorRoom.java
+++ b/src/main/java/io/github/ytung/tractor/TractorRoom.java
@@ -516,7 +516,11 @@ public class TractorRoom {
 
     private void sendSync(String playerId, Broadcaster broadcaster, OutgoingMessage message) {
         if (humanControllers.containsKey(playerId))
-            humanControllers.get(playerId).write(JacksonEncoder.INSTANCE.encode(message));
+            try {
+                humanControllers.get(playerId).write(JacksonEncoder.INSTANCE.encode(message));
+            } catch (RuntimeException e) {
+                // client disconnected, ignore
+            }
         else if (aiControllers.containsKey(playerId))
             aiControllers.get(playerId).processMessage(game, message, inputMessage -> handleGameMessage(playerId, broadcaster, inputMessage));
     }


### PR DESCRIPTION
Fixes #3 

The `onDisconnect` handler removes a disconnected client from the `humanControllers` map, but there's no guarantee that it's removed before `sendSync` runs.

Also we're not synchronizing the `containsKey` and `get` calls, but this try-catch will handle that case too. It's fine to ignore these errors here.